### PR TITLE
Docker caicloud

### DIFF
--- a/extras/docker/stable/Dockerfile
+++ b/extras/docker/stable/Dockerfile
@@ -5,18 +5,16 @@ MAINTAINER Luis Pabón <lpabon@redhat.com>
 LABEL version="1.0"
 LABEL description="Centos 7 docker image for Heketi"
 
-RUN yum --setopt=tsflags=nodocs -q -y update; yum clean all;
-RUN yum --setopt=tsflags=nodocs -q -y install epel-release && \
-    yum --setopt=tsflags=nodocs -q -y install heketi && \
-    yum -y autoremove && \
-    yum -y clean all
+ADD heketi /usr/bin/heketi
 
 # post install config and volume setup
 VOLUME /etc/heketi
-VOLUME /var/lib/heketi
-
+ADD heketi.json /var/lib/heketi/heketi.json
+ADD heketi-cli /usr/bin/heketi-cli
+ADD load_cluster /usr/bin/load_cluster 
+ADD init_heketi.sh /usr/bin/init_heketi.sh
 # expose port, set user and set entrypoint with config option
 ENTRYPOINT ["/usr/bin/heketi"]
 EXPOSE 8080
 
-CMD ["--config=/etc/heketi/heketi.json"]
+CMD ["-config=/var/lib/heketi/heketi.json"]

--- a/extras/docker/stable/heketi.json
+++ b/extras/docker/stable/heketi.json
@@ -9,11 +9,11 @@
 	"jwt" : {
 		"_admin" : "Admin has access to all APIs",
 		"admin" : {
-			"key" : "My Secret"
+			"key" : "caicloudAdmin9138"
 		},
 		"_user" : "User only has access to /volumes endpoint",
 		"user" : { 
-			"key" : "My Secret"
+			"key" : "caicloudUser9138"
 		}
 	},
 
@@ -21,9 +21,13 @@
 	"glusterfs" : {
 
 		"_executor_comment": "Execute plugin. Possible choices: mock, ssh",
-		"executor" : "mock",
+		"executor" : "ssh",
+		"sshexec": {
+			"user": "root",
+			"keyfile": "/root/.ssh/id_rsa"
 
+		},
 		"_db_comment": "Database file name",
-		"db" : "/var/lib/heketi/heketi.db"
+		"db" : "/etc/heketi/heketi.db"
 	}
 }

--- a/extras/docker/stable/init_heketi.sh
+++ b/extras/docker/stable/init_heketi.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Create the topology for heketi
+sleep 2
+if [ ! -z $VOLUME_PATH ]; then
+	volume_path="$VOLUME_PATH"
+	records="${VOLUME_PATH}/loaded_records"
+else
+	volume_path="/etc/heketi"
+	records="/etc/heketi/loaded_records"
+fi
+if [ ! -f records ]; then
+	touch $records
+fi
+
+IFS=';' read -ra clusters <<< "$CLUSTERS"
+for cluster in "${clusters[@]}"; do
+	if grep -q "$cluster" $records; then
+		echo "$cluster already loaded; skip"
+		continue
+	else
+	    echo "loading $cluster"
+	fi
+    printf "{\"clusters\":[\n\t{\"nodes\":[" > $volume_path/tmp-topology.json
+    IFS=',' read -ra nodes <<< "$cluster"
+    flag=0
+    for node in "${nodes[@]}"; do
+	    echo "adding $node"
+    	if [ $flag -eq 1 ]; then
+	    	printf ",\n" >> $volume_path/tmp-topology.json
+	    else 
+	    	printf "\n" >> $volume_path/tmp-topology.json
+	    	flag=1
+	    fi
+    	printf "\t\t{\"node\":{ \"hostnames\":{\"manage\":[\"$node\"],\"storage\":[\"$node\"]},\"zone\":1}," >> $volume_path/tmp-topology.json
+    	printf "\"devices\":[\"$PARTITION\"]}" >> $volume_path/tmp-topology.json
+    done
+    printf "\n\t]}\n\t]\n}" >> $volume_path/tmp-topology.json
+    load_cluster $volume_path/tmp-topology.json
+    echo "$cluster" >> $records
+done

--- a/extras/docker/stable/load_cluster
+++ b/extras/docker/stable/load_cluster
@@ -1,0 +1,3 @@
+#! /bin/bash
+export HEKETI_CLI_SERVER=http://localhost:8080
+heketi-cli load --json=$1


### PR DESCRIPTION
和上游的相比：

- 添加了容器初始化脚本
- 添加了heketi-cli，用来跟heketi-server交互
- 添加了load_cluster这个脚本，方便售前加载集群
- heketi 配置改成用ssh，而不是mock

其他与上游相同。